### PR TITLE
Validate team URLs

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,8 @@ const teamDataSpecificFile = './output/team-data-specific.csv';
 const scanType = process.argv[2];
 const specificTeamId = process.argv[3];
 
+const TEAM_URL_PATTERN = /\/team\/\d+\//;
+
 // Lista de equipos para pruebas
 const testTeams = [
     'https://sofifa.com/team/243/real-madrid/',
@@ -52,8 +54,12 @@ async function download(fileToRead, fileToWrite, includeVersionHistory = true) {
 
     let count = 0;
     console.time('Escaneo completo');
-    
+
     for (let url of teamUrlList) {
+        if (!TEAM_URL_PATTERN.test(url)) {
+            console.warn(`URL inválida omitida: ${url}`);
+            continue;
+        }
         try {
             console.log(`Procesando equipo (${++count}/${teamUrlList.length}): ${url}`);
             let rows = await getTeamDetailsCsvRow(url, includeVersionHistory);

--- a/services/team-urls-loader.js
+++ b/services/team-urls-loader.js
@@ -8,6 +8,8 @@ const teamUrlsFullFile = './files/team-urls-full.csv';
 const teamUrlsTestFile = './files/team-urls-test.csv';
 const teamUrlsSpecificFile = './files/team-urls-specific.csv';
 
+const TEAM_URL_PATTERN = /\/team\/\d+\//;
+
 /**
  * Este método obtiene todas las URLs de páginas de equipos de sofifa.com
  * @returns {Promise<void>}
@@ -29,19 +31,23 @@ async function loadTeamUrlsFile(scanType = 'full') {
         const teams = [];
         $('a[href*="/team/"]').each((i, el) => {
             const href = $(el).attr('href');
-            if (href && href.match(/\/team\/\d+/)) {
-                const fullUrl = SOFIFA_BASE_URL + href;
+            if (!href) return;
+            const fullUrl = SOFIFA_BASE_URL + href;
+            if (TEAM_URL_PATTERN.test(fullUrl)) {
                 if (!teams.includes(fullUrl)) {
                     teams.push(fullUrl);
                 }
+            } else {
+                console.warn(`URL inválida encontrada y omitida: ${fullUrl}`);
             }
         });
-        
+
         if (teams.length > 0) {
-            const teamIds = teams.join('\n') + '\n';
+            const validTeams = teams.filter(url => TEAM_URL_PATTERN.test(url));
+            const teamIds = validTeams.join('\n') + '\n';
             fs.appendFileSync(teamUrlsFileToWrite, teamIds);
-            totalTeams += teams.length;
-            console.log(`Descargadas URLs de equipos: ${teams.length} (total=${totalTeams})`);
+            totalTeams += validTeams.length;
+            console.log(`Descargadas URLs de equipos: ${validTeams.length} (total=${totalTeams})`);
         }
         
         // Verificar si hay más páginas


### PR DESCRIPTION
## Summary
- ensure only valid team URLs are processed and logged otherwise
- filter invalid team links when building the URL list

## Testing
- `npm test` *(fails: tunneling socket could not be established, statusCode=403)*

------
https://chatgpt.com/codex/tasks/task_e_68a87fab04608330a1e561cffd5211f5